### PR TITLE
Add fall detection binary sensor to dfrobot_sen0623

### DIFF
--- a/esphome/components/dfrobot_sen0623/README.md
+++ b/esphome/components/dfrobot_sen0623/README.md
@@ -1,0 +1,9 @@
+# DFRobot SEN0623
+
+Support for the [DFRobot SEN0623](https://www.dfrobot.com/product-2117.html) mmWave radar sensor.
+
+## Binary Sensors
+
+- `presence` – detects human presence.
+- `fall_detected` – indicates if a fall event was detected by the sensor.
+

--- a/esphome/components/dfrobot_sen0623/binary_sensor.py
+++ b/esphome/components/dfrobot_sen0623/binary_sensor.py
@@ -9,6 +9,7 @@ from . import CONF_DFROBOT_SEN0623_ID, DfrobotSen0623Component
 DEPENDENCIES = ["dfrobot_sen0623"]
 
 CONF_PRESENCE = "presence"
+CONF_FALL_DETECTED = "fall_detected"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -17,6 +18,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_PRESENCE): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_PRESENCE
             ),
+            cv.Optional(CONF_FALL_DETECTED): binary_sensor.binary_sensor_schema(),
         }
     )
 )
@@ -28,3 +30,7 @@ async def to_code(config):
     if presence := config.get(CONF_PRESENCE):
         sens = await binary_sensor.new_binary_sensor(presence)
         cg.add(parent.set_presence_binary_sensor(sens))
+
+    if fall := config.get(CONF_FALL_DETECTED):
+        sens = await binary_sensor.new_binary_sensor(fall)
+        cg.add(parent.set_fall_detected_binary_sensor(sens))

--- a/esphome/components/dfrobot_sen0623/dfrobot_sen0623.cpp
+++ b/esphome/components/dfrobot_sen0623/dfrobot_sen0623.cpp
@@ -12,6 +12,7 @@ std::pair<uint8_t, uint8_t> OP_REQ_HUMAN_PRESENCE = {0x80, 0x81};
 std::pair<uint8_t, uint8_t> OP_REQ_HUMAN_MOVEMENT = {0x80, 0x82};
 std::pair<uint8_t, uint8_t> OP_REQ_HUMAN_MOVE_RANGE = {0x80, 0x83};
 std::pair<uint8_t, uint8_t> OP_REQ_HUMAN_DISTANCE = {0x80, 0x84};
+std::pair<uint8_t, uint8_t> OP_REQ_FALL_DETECTED = {0x80, 0x85};
 std::pair<uint8_t, uint8_t> OP_SET_MODE = {0x02, 0x08};
 
 namespace esphome {
@@ -187,6 +188,10 @@ bool DfrobotSen0623Component::process_packet(uint8_t *packetData, size_t len) {
         if (this->human_move_range_sensor_ != nullptr) {
           this->human_move_range_sensor_->publish_state(data[0]);
         }
+      } else if (operation == OP_REQ_FALL_DETECTED) {
+        if (this->fall_detected_binary_sensor_ != nullptr) {
+          this->fall_detected_binary_sensor_->publish_state(data[0] != 0);
+        }
       } else if (operation == OP_REQ_MODE) {
         if (this->status_text_sensor_ != nullptr) {
           switch (data[0]) {
@@ -310,6 +315,10 @@ void DfrobotSen0623Component::loop() {
     // this->wait_for_packet(OP_REQ_HUMAN_DISTANCE);
     this->request(OP_REQ_HUMAN_MOVE_RANGE);
     // this->wait_for_packet(OP_REQ_HUMAN_MOVE_RANGE);
+    if (this->status_text_sensor_ != nullptr && this->status_text_sensor_->state == "fall") {
+      this->request(OP_REQ_FALL_DETECTED);
+      // this->wait_for_packet(OP_REQ_FALL_DETECTED);
+    }
   }
 
   uint8_t packetData[100];  // adjust size as needed

--- a/esphome/components/dfrobot_sen0623/dfrobot_sen0623.h
+++ b/esphome/components/dfrobot_sen0623/dfrobot_sen0623.h
@@ -74,6 +74,9 @@ class DfrobotSen0623Component : public uart::UARTDevice, public PollingComponent
   }
   // binary_sensor
   void set_presence_binary_sensor(binary_sensor::BinarySensor *presence_sensor) { presence_sensor_ = presence_sensor; }
+  void set_fall_detected_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
+    fall_detected_binary_sensor_ = binary_sensor;
+  }
   // button
   void set_reset_button(button::Button *reset_button) { reset_button_ = reset_button; }
   // switch
@@ -94,6 +97,7 @@ class DfrobotSen0623Component : public uart::UARTDevice, public PollingComponent
   sensor::Sensor *human_distance_sensor_{nullptr};
   sensor::Sensor *human_move_range_sensor_{nullptr};
   binary_sensor::BinarySensor *presence_sensor_{nullptr};
+  binary_sensor::BinarySensor *fall_detected_binary_sensor_{nullptr};
 
   text_sensor::TextSensor *status_text_sensor_{nullptr};
   text_sensor::TextSensor *movement_text_sensor_{nullptr};

--- a/tests/components/dfrobot_sen0623/common.yaml
+++ b/tests/components/dfrobot_sen0623/common.yaml
@@ -12,3 +12,10 @@ select:
     mode:
       name: Mode
       initial_option: fall
+
+binary_sensor:
+  - platform: dfrobot_sen0623
+    dfrobot_sen0623_id: mmwave
+    fall_detected:
+      name: Fall Detected
+


### PR DESCRIPTION
## Summary
- add configurable `fall_detected` binary sensor for SEN0623 radar
- expose fall-detection binary sensor in component API and handle opcode
- document usage and add test sample

## Testing
- `script/lint-cpp esphome/components/dfrobot_sen0623/dfrobot_sen0623.cpp esphome/components/dfrobot_sen0623/dfrobot_sen0623.h` (fails: Tunnel connection failed: 403 Forbidden)
- `python script/lint-python esphome/components/dfrobot_sen0623/binary_sensor.py` (fails: FileNotFoundError: [Errno 2] No such file or directory: 'flake8')
- `pytest tests/components/dfrobot_sen0623` (fails: pytest: error: unrecognized arguments: --cov=esphome --cov-branch)


------
https://chatgpt.com/codex/tasks/task_e_68ae673a9364832d8e889dc9b9a19cab